### PR TITLE
feat: 이메일 인증 완료 시 회원상태의 is_verified 가 true로 변경되면서 로그인 기능 활성화

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ repositories {
 }
 
 dependencies {
-    //web
+    // web
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
@@ -60,7 +60,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     testImplementation 'org.springframework.security:spring-security-test'
 
-    //dev tools
+    // dev tools
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
 
     // oauth2
@@ -68,6 +68,12 @@ dependencies {
 
     // localDateTime
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
+
+    // redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+    // e-mail
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/meetty/auth/controller/AuthController.java
+++ b/src/main/java/com/example/meetty/auth/controller/AuthController.java
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
@@ -25,6 +26,7 @@ import org.springframework.web.multipart.MultipartFile;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api")
+@Tag(name = "회원 관련 API", description = "회원가입, 로그인, 회원탈퇴 같이 회원 데이터와 관련된 API")
 public class AuthController {
 
     private final UserService userService;
@@ -58,6 +60,6 @@ public class AuthController {
 
         userService.signUp(signUpDto, profileImage);
 
-        return ResponseEntity.ok(ApiResponse.success("회원가입이 완료되었습니다."));
+        return ResponseEntity.ok(ApiResponse.success("회원가입이 완료되었습니다. 이메일 인증을 완료해주세요."));
     }
 }

--- a/src/main/java/com/example/meetty/auth/entity/UserEntity.java
+++ b/src/main/java/com/example/meetty/auth/entity/UserEntity.java
@@ -40,6 +40,9 @@ public class UserEntity {
     @Enumerated(EnumType.STRING)
     private UserRole role;
 
+    @Column(name = "is_verified", nullable = false)
+    private boolean isVerified = false;
+
     @Column(name = "created_at")
     private LocalDateTime createdAt;
 

--- a/src/main/java/com/example/meetty/auth/service/UserService.java
+++ b/src/main/java/com/example/meetty/auth/service/UserService.java
@@ -6,14 +6,18 @@ import com.example.meetty.auth.entity.UserRole;
 import com.example.meetty.auth.repository.UserRepository;
 import com.example.meetty.global.exception.AppException;
 import com.example.meetty.global.exception.ErrorCode;
+import com.example.meetty.global.mail.service.EmailService;
 import com.example.meetty.global.util.PasswordUtil;
 import com.example.meetty.image.service.UserImageService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.time.Duration;
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -22,6 +26,8 @@ public class UserService {
     private final UserRepository userRepository;
     private final PasswordUtil passwordUtil;
     private final UserImageService userImageService;
+    private final RedisTemplate<String, String> redisTemplate;
+    private final EmailService emailService;
 
     public void signUp(SignUpDto signUpDto, MultipartFile profileImage) throws Exception {
         if (userRepository.findByEmail(signUpDto.getEmail()).isPresent()) {
@@ -38,6 +44,7 @@ public class UserService {
                 .username(signUpDto.getUsername())
                 .address(signUpDto.getAddress())
                 .role(UserRole.ROLE_USER)
+                .isVerified(false)
                 .createdAt(LocalDateTime.now())
                 .build();
 
@@ -48,9 +55,19 @@ public class UserService {
         }
 
         UserEntity savedUser = userRepository.save(userEntity);
-
         userImageService.uploadUserImage(savedUser, profileImage, isDefaultImage);
 
-        log.info("✅ 회원가입 완료 - 이메일: {}", savedUser.getEmail());
+        // 이메일로 인증링크 발송
+        String token = UUID.randomUUID().toString();
+        redisTemplate.opsForValue().set("emailToken:" + token, savedUser.getEmail(), Duration.ofMinutes(60));
+
+        try {
+            emailService.sendVerificationLink(savedUser.getEmail(), token);
+        } catch (Exception e) {
+            log.error("❌ 이메일 전송 실패 - 회원가입 롤백: {}", savedUser.getEmail());
+            throw new AppException(ErrorCode.EMAIL_SEND_FAIL, ErrorCode.EMAIL_SEND_FAIL.getMessage());
+        }
+
+        log.info("✅ 회원가입 완료 - 이메일: {}, 인증 링크 발송됨", savedUser.getEmail());
     }
 }

--- a/src/main/java/com/example/meetty/global/config/redis/RedisConfig.java
+++ b/src/main/java/com/example/meetty/global/config/redis/RedisConfig.java
@@ -1,0 +1,25 @@
+package com.example.meetty.global.config.redis;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory();
+    }
+
+    @Bean
+    public RedisTemplate<String, String> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(connectionFactory);
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        return redisTemplate;
+    }
+}

--- a/src/main/java/com/example/meetty/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/meetty/global/exception/ErrorCode.java
@@ -21,7 +21,14 @@ public enum ErrorCode {
     NOT_FOUND_COOKIE(HttpStatus.NOT_FOUND, "쿠키 값이 존재하지 않습니다. 다시 로그인 해주세요."),
     INCORRECT_REFRESH_TOKEN(HttpStatus.CONFLICT, "Refresh Token 이 일치하지 않습니다."),
     INVALID_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "유효하지 않은 토큰입니다. 다시 로그인 해주세요."),
-    IMAGE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "이미지 업로드에 실패하였습니다." );
+    IMAGE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "이미지 업로드에 실패하였습니다." ),
+
+    // Email 에러코드
+    EMAIL_SEND_FAIL(HttpStatus.BAD_REQUEST, "이메일 전송에 실패하였습니다."),
+    INVALID_EMAIL_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 이메일 인증 토큰입니다."),
+    EMAIL_ALREADY_VERIFIED(HttpStatus.CONFLICT, "이미 인증한 이메일 입니다")
+
+    ;
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/example/meetty/global/mail/controller/EmailVerificationController.java
+++ b/src/main/java/com/example/meetty/global/mail/controller/EmailVerificationController.java
@@ -1,0 +1,58 @@
+package com.example.meetty.global.mail.controller;
+
+import com.example.meetty.auth.entity.UserEntity;
+import com.example.meetty.auth.repository.UserRepository;
+import com.example.meetty.global.dto.ApiResponse;
+import com.example.meetty.global.exception.AppException;
+import com.example.meetty.global.exception.ErrorCode;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/auth")
+@Tag(name = "이메일 인증 API", description = "이메일 인증 관련 API ")
+public class EmailVerificationController {
+    private final RedisTemplate<String, String> redisTemplate;
+    private final UserRepository userRepository;
+
+    @Operation(summary = "이메일 인증", description = "회원가입 후 이메일로 받은 토큰을 검증하여 인증상태로 전환합니다.")
+    @GetMapping("/verify")
+    public ResponseEntity<ApiResponse<String>> verifyMail(
+            @Parameter(description = "이메일 인증 토큰")
+            @RequestParam String token
+    ) {
+        String redisKey = "emailToken:" + token;
+        String email = redisTemplate.opsForValue().get(redisKey);
+        log.info("📦 Redis에서 가져온 이메일: {}", email);
+
+        if (email == null) {
+            return ResponseEntity.badRequest().body(ApiResponse.fail(ErrorCode.INVALID_EMAIL_TOKEN));
+        }
+
+        UserEntity userEntity = userRepository.findByEmail(email).orElseThrow(
+                () -> new AppException(ErrorCode.USER_EMAIL_NOT_FOUND, ErrorCode.USER_EMAIL_NOT_FOUND.getMessage())
+        );
+
+        if (userEntity.isVerified()) {
+            redisTemplate.delete(redisKey);
+            return ResponseEntity.badRequest().body(ApiResponse.fail(ErrorCode.EMAIL_ALREADY_VERIFIED));
+        }
+
+        userEntity.setVerified(true);
+        userRepository.save(userEntity);
+        redisTemplate.delete(redisKey);
+
+        return ResponseEntity.ok(ApiResponse.success("이메일 인증이 완료되었습니다."));
+    }
+}

--- a/src/main/java/com/example/meetty/global/mail/service/EmailService.java
+++ b/src/main/java/com/example/meetty/global/mail/service/EmailService.java
@@ -1,0 +1,51 @@
+package com.example.meetty.global.mail.service;
+
+import com.example.meetty.global.exception.AppException;
+import com.example.meetty.global.exception.ErrorCode;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class EmailService {
+
+    private final JavaMailSender javaMailSender;
+
+    @Value("${app.base-url}")
+    private String baseUrl;
+
+    public void sendVerificationLink(String email, String token) throws MessagingException {
+
+
+        String verifyUrl =  baseUrl +"/api/auth/verify?token=" + token;
+
+        MimeMessage mimeMessage = javaMailSender.createMimeMessage();
+        MimeMessageHelper helper = new MimeMessageHelper(mimeMessage, false, "UTF-8");
+        helper.setFrom("violetcarrot21@gmail.com"); // Gmail 계정과 동일해야 함
+        helper.setTo(email);
+        helper.setSubject("회원가입 이메일 인증");
+        helper.setText("""
+                아래 링크를 클릭하여 이메일 인증을 완료해주세요:
+
+                %s
+
+                ※ 본 링크는 1시간 동안만 유효합니다.
+                """.formatted(verifyUrl));
+
+        try {
+            javaMailSender.send(mimeMessage);
+            log.info("✅ 이메일 인증 링크 전송 완료: {}", email);
+        } catch (Exception e) {
+            log.error("❌ 이메일 전송 실패: {}", e.getMessage(), e);
+            throw new AppException(ErrorCode.EMAIL_SEND_FAIL, ErrorCode.EMAIL_SEND_FAIL.getMessage());
+        }
+    }
+}

--- a/src/main/resources/SQL/user.sql
+++ b/src/main/resources/SQL/user.sql
@@ -1,0 +1,18 @@
+CREATE TABLE users(
+    user_id BIGINT PRIMARY KEY AUTO_INCREMENT,
+    email VARCHAR(100) NOT NULL,
+    password VARCHAR(255) NOT NULL,
+    username VARCHAR(20) UNIQUE NOT NULL,
+    address VARCHAR(100) NOT NULL,
+    provider VARCHAR(20),
+    provider_id VARCHAR(255),
+    role VARCHAR(20) NOT NULL,
+    is_verified TINYINT NOT NULL DEFAULT 0,
+    created_at DATETIME NOT NULL
+);
+
+CREATE TABLE user_images(
+    image_id BIGINT PRIMARY KEY AUTO_INCREMENT,
+    url VARCHAR(255) NOT NULL,
+    user_id BIGINT NOT NULL
+);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,3 +7,21 @@ spring:
         token:
             access-expiration-time: 43200000    # 12??
             refresh-expiration-time: 604800000
+
+    data:
+        redis:
+            host: localhost
+            port: 6379
+
+    mail:
+        host: smtp.gmail.com
+        port: 587
+        username: violetcarrot21@gmail.com
+        password: uhrk bhbx mvum raox
+        properties:
+            mail.smtp.auth: true
+            mail.smtp.starttls.enable: true
+            mail.debug: true
+
+app:
+    base-url: http://localhost:8080


### PR DESCRIPTION
1. build.gradle 파일에 redis, 이메일 기능 관련된 dependency 추가

2. yml파일에 관련 설정 추가 & GMAIL_USER, GMAIL_PASSWORD 환경 변수 설정

3. redisConfig 추가

4. global 패키지에 mail 패키지를 추가하고 회원가입 인증 메일 발송 service 추가

5. 회원 가입 인증 토큰을 링크로 보내면서 Redis에 유효시간 1시간으로 토큰 저장
- Redis에서 토큰 저장하는 것 확인했습니다.

6. 회원 가입 API에서 이메일 인증 API 활용 

7. 이메일로 보낸 링크를 클릭하면 isVerified가 true로 변경되면서 로그인창으로 이동
- 네이버, 구글같은 이메일 서비스를 하는 곳에서 localhost를 하이퍼링크로 인식하지 않기 때문에 링크로 기능하지 않지만 임시로 하이퍼링크로 인식하는 주소를 넣었을 때 링크가 활성화되는 것까지 확인했습니다.

- 지금은 JSON 응답 형식으로 코드를 작성했지만 배포가 된다면 하이퍼링크 클릭 시 인증에 성공한다면 로그인 창으로, 실패한다면 인증 실패 창으로 리다이렉트 하는 방법을 생각 중입니다.

- 인증 실패 창에 "메일을 받지 못하셨다면, 스팸 메일함을 확인해보세요.", "1시간이 지난 경우, 다시 회원가입을 진행해 주세요." 같은 내용을 넣는 것은 어떤지 고민 중입니다.