### PR TITLE
jwt에 userId 추가 + 회원탈퇴 구현

### DIFF
--- a/src/main/java/com/example/meetty/auth/controller/AuthController.java
+++ b/src/main/java/com/example/meetty/auth/controller/AuthController.java
@@ -1,9 +1,6 @@
 package com.example.meetty.auth.controller;
 
-import com.example.meetty.auth.dto.LoginRequestDto;
-import com.example.meetty.auth.dto.LoginResponseDto;
-import com.example.meetty.auth.dto.RefreshTokenResponseDto;
-import com.example.meetty.auth.dto.SignUpDto;
+import com.example.meetty.auth.dto.*;
 import com.example.meetty.auth.entity.UserEntity;
 import com.example.meetty.auth.repository.UserRepository;
 import com.example.meetty.auth.service.UserService;
@@ -21,6 +18,7 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
@@ -81,18 +79,9 @@ public class AuthController {
 
         log.info("[POST] 로그인 요청");
 
-        UserEntity userEntity = userRepository.findByEmail(loginRequestDto.getEmail()).orElseThrow(
-                () -> new AppException(ErrorCode.USER_EMAIL_NOT_FOUND, ErrorCode.USER_EMAIL_NOT_FOUND.getMessage())
-        );
-
-        if (!userEntity.isVerified() && userEntity.getProvider() == null) {
-            throw new AppException(ErrorCode.EMAIL_NOT_VERIFIED, ErrorCode.EMAIL_NOT_VERIFIED.getMessage());
-        }
-
         try {
             LoginResponseDto loginResponseDto = userService.login(loginRequestDto, httpServletResponse);
             return ResponseEntity.ok(ApiResponse.success(loginResponseDto));
-
         } catch (AppException e) {
             return ResponseEntity.status(e.getErrorCode().getHttpStatus()).body(ApiResponse.fail(e.getErrorCode()));
         }
@@ -117,16 +106,39 @@ public class AuthController {
 
     @Operation(summary = "로그아웃", description = "로그아웃 API.")
     @SecurityRequirement(name = "bearerAuth")
-    @PostMapping("/logout")
+    @PostMapping("/v1/logout")
     public ResponseEntity<ApiResponse<String>> logout(
             @AuthenticationPrincipal CustomUserDetails customUserDetails,
             HttpServletResponse response) {
 
-        String email = customUserDetails.getUsername();
-        userService.logout(email, response);
+        Long userId = customUserDetails.getUserId();
+        userService.logout(userId, response);
 
-        log.info("[POST] 로그아웃: {}", email);
+        log.info("[POST] 로그아웃: {}", userId);
 
         return ResponseEntity.ok(ApiResponse.success("로그아웃 되었습니다."));
+    }
+
+    @Operation(summary = "회원탈퇴", description = "회원탈퇴 API 입니다.")
+    @SecurityRequirement(name = "bearerAuth")
+    @PutMapping("/v1/withdrawal")
+    public ResponseEntity<ApiResponse<String>> withdrawalUser(
+            @RequestBody PasswordRequestDto passwordRequestDto,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
+            HttpSession httpSession,
+            HttpServletResponse httpServletResponse) {
+
+        log.info("[PUT] 회원탈퇴 요청 - {}", customUserDetails.getUsername());
+
+        try {
+            String loginEmail = customUserDetails.getUsername();
+            String requestBodyPassword = passwordRequestDto.getPassword();
+            userService.withdrawalUser(loginEmail, requestBodyPassword, httpSession, httpServletResponse);
+
+            return ResponseEntity.ok(ApiResponse.success("회원탈퇴가 완료되었습니다."));
+        } catch (AppException e) {
+            return ResponseEntity.status(e.getErrorCode().getHttpStatus())
+                    .body(ApiResponse.fail(e.getErrorCode()));
+        }
     }
 }

--- a/src/main/java/com/example/meetty/auth/dto/PasswordRequestDto.java
+++ b/src/main/java/com/example/meetty/auth/dto/PasswordRequestDto.java
@@ -1,0 +1,12 @@
+package com.example.meetty.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+public class PasswordRequestDto {
+    @NotBlank(message = "비밀번호를 입력해주세요.")
+    private String password;
+}

--- a/src/main/java/com/example/meetty/auth/service/RefreshTokenRedisService.java
+++ b/src/main/java/com/example/meetty/auth/service/RefreshTokenRedisService.java
@@ -15,16 +15,16 @@ public class RefreshTokenRedisService {
     private final RedisTemplate<String, String> redisTemplate;
     private static final String PREFIX = "refresh_token:";
 
-    public void saveRefreshToken(String email, String token, Duration ttl) {
-        String key = PREFIX + email;
+    public void saveRefreshToken(Long userId, String token, Duration ttl) {
+        String key = PREFIX + userId;
         redisTemplate.opsForValue().set(key, token, ttl.toMillis(), TimeUnit.MILLISECONDS);
     }
 
-    public Optional<String> getRefreshTokenByEmail(String email) {
-        return Optional.ofNullable(redisTemplate.opsForValue().get(PREFIX + email));
+    public Optional<String> getRefreshTokenByUserId(Long userId) {
+        return Optional.ofNullable(redisTemplate.opsForValue().get(PREFIX + userId));
     }
 
-    public void deleteToken(String email) {
-        redisTemplate.delete(PREFIX + email);
+    public void deleteToken(Long userId) {
+        redisTemplate.delete(PREFIX + userId);
     }
 }

--- a/src/main/java/com/example/meetty/auth/service/UserService.java
+++ b/src/main/java/com/example/meetty/auth/service/UserService.java
@@ -13,13 +13,18 @@ import com.example.meetty.global.jwt.JwtTokenProvider;
 import com.example.meetty.global.mail.service.EmailService;
 import com.example.meetty.global.util.PasswordUtil;
 import com.example.meetty.image.service.UserImageService;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.java.Log;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -45,7 +50,10 @@ public class UserService {
     private long refreshExpirationTime;
     @Value("${spring.jwt.secure-cookie}")
     private boolean secureCookie;
+    @PersistenceContext
+    private EntityManager entityManager;
 
+    @Transactional
     public void signUp(SignUpDto signUpDto, MultipartFile profileImage) throws Exception {
         if (userRepository.findByEmail(signUpDto.getEmail()).isPresent()) {
             throw new AppException(ErrorCode.USER_EMAIL_DUPLICATED, ErrorCode.USER_EMAIL_DUPLICATED.getMessage());
@@ -93,17 +101,22 @@ public class UserService {
                 () -> new AppException(ErrorCode.USER_EMAIL_NOT_FOUND, ErrorCode.USER_EMAIL_NOT_FOUND.getMessage())
         );
 
+        if (!userEntity.isVerified() && userEntity.getProvider() == null) {
+            throw new AppException(ErrorCode.EMAIL_NOT_VERIFIED, ErrorCode.EMAIL_NOT_VERIFIED.getMessage());
+        }
+
         if(!Objects.equals(passwordUtil.encrypt(loginRequestDto.getPassword()), userEntity.getPassword())) {
             throw new AppException(ErrorCode.NOT_EQUAL_PASSWORD, ErrorCode.NOT_EQUAL_PASSWORD.getMessage());
         }
 
         String email = userEntity.getEmail();
         String role = userEntity.getRole().getType();
+        Long userId = userEntity.getUserId();
 
-        String accessToken = jwtTokenProvider.createAccessToken(email, role);
-        String refreshToken = jwtTokenProvider.createRefreshToken(email, role);
+        String accessToken = jwtTokenProvider.createAccessToken(email, userId,role);
+        String refreshToken = jwtTokenProvider.createRefreshToken(email, userId, role);
 
-        refreshTokenRedisService.saveRefreshToken(email, refreshToken, Duration.ofMillis(refreshExpirationTime));
+        refreshTokenRedisService.saveRefreshToken(userId, refreshToken, Duration.ofMillis(refreshExpirationTime));
 
         httpServletResponse.addHeader("Authorization", "Bearer " + accessToken);
         Cookie refreshCookie = new Cookie("refresh_token", refreshToken);
@@ -126,7 +139,6 @@ public class UserService {
                 .build();
     }
 
-    @Transactional
     public RefreshTokenResponseDto refreshToken(HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse) {
         String refreshToken = getRefreshTokenFromCookie(httpServletRequest);
 
@@ -135,8 +147,12 @@ public class UserService {
         }
 
         String email = jwtTokenProvider.getEmailByToken(refreshToken);
+        UserEntity userEntity = userRepository.findByEmail(email).orElseThrow(
+                () -> new AppException(ErrorCode.USER_EMAIL_NOT_FOUND, ErrorCode.USER_EMAIL_NOT_FOUND.getMessage())
+        );
+        Long userId = userEntity.getUserId();
 
-        String savedRefreshToken = refreshTokenRedisService.getRefreshTokenByEmail(email).orElseThrow(
+        String savedRefreshToken = refreshTokenRedisService.getRefreshTokenByUserId(userId).orElseThrow(
                 () -> new AppException(ErrorCode.NOT_FOUND_REFRESH_TOKEN, ErrorCode.NOT_FOUND_REFRESH_TOKEN.getMessage())
         );
 
@@ -144,16 +160,13 @@ public class UserService {
             throw new AppException(ErrorCode.INCORRECT_REFRESH_TOKEN, ErrorCode.INCORRECT_REFRESH_TOKEN.getMessage());
         }
 
-        UserEntity userEntity = userRepository.findByEmail(email).orElseThrow(
-                () -> new AppException(ErrorCode.USER_EMAIL_NOT_FOUND, ErrorCode.USER_EMAIL_NOT_FOUND.getMessage())
-        );
-
-        String newAccessToken = jwtTokenProvider.createAccessToken(email, userEntity.getRole().getType());
-        String newRefreshToken = jwtTokenProvider.createRefreshToken(email, userEntity.getRole().getType());
+        String newAccessToken = jwtTokenProvider.createAccessToken(email, userId, userEntity.getRole().getType());
+        String newRefreshToken = jwtTokenProvider.createRefreshToken(email, userId, userEntity.getRole().getType());
 
         setRefreshTokenCookie(httpServletResponse, newRefreshToken);
 
-        refreshTokenRedisService.saveRefreshToken(email, newRefreshToken, Duration.ofMillis(refreshExpirationTime));
+        // ✅ 이메일 → userId 기준으로 저장
+        refreshTokenRedisService.saveRefreshToken(userEntity.getUserId(), newRefreshToken, Duration.ofMillis(refreshExpirationTime));
 
         log.info("✅ 토큰 재발급 성공 - 이메일: {}", email);
         log.info("🔑 AccessToken: {}", newAccessToken);
@@ -191,8 +204,8 @@ public class UserService {
         httpServletResponse.addCookie(refreshCookie);
     }
 
-    public void logout(String email, HttpServletResponse response) {
-        refreshTokenRedisService.deleteToken(email);
+    public void logout(Long userId, HttpServletResponse response) {
+        refreshTokenRedisService.deleteToken(userId);
 
         Cookie cookie = new Cookie("refresh_token", null);
         cookie.setHttpOnly(true);
@@ -200,5 +213,30 @@ public class UserService {
         cookie.setPath("/");
         cookie.setMaxAge(0); // 즉시 만료
         response.addCookie(cookie);
+    }
+
+    // TODO: 회원탈퇴 시 관련된 거 전부 제거하기 cascade = CascadeType.REMOVE, orphanRemoval = true 설정
+    @Transactional
+    public void withdrawalUser(String loginEmail, String requestBodyPassword, HttpSession httpSession, HttpServletResponse httpServletResponse) {
+        UserEntity userEntity = userRepository.findByEmail(loginEmail).orElseThrow(
+                () -> new AppException(ErrorCode.USER_EMAIL_NOT_FOUND, ErrorCode.USER_EMAIL_NOT_FOUND.getMessage())
+        );
+
+        if (!Objects.equals(passwordUtil.encrypt(requestBodyPassword), userEntity.getPassword())) {
+            throw new AppException(ErrorCode.NOT_EQUAL_PASSWORD, ErrorCode.NOT_EQUAL_PASSWORD.getMessage());
+        }
+
+        logout(userEntity.getUserId(), httpServletResponse);
+
+        userRepository.delete(userEntity);
+
+        entityManager.flush();
+        entityManager.clear();
+        log.info("Hibernate 캐시 정리 완료");
+
+        httpSession.invalidate();
+        SecurityContextHolder.clearContext();
+
+        log.info("회원탈퇴 완료 - ID: {}", userEntity.getUserId());
     }
 }

--- a/src/main/java/com/example/meetty/global/config/auth/CustomUserDetails.java
+++ b/src/main/java/com/example/meetty/global/config/auth/CustomUserDetails.java
@@ -48,6 +48,9 @@ public class CustomUserDetails implements UserDetails, OAuth2User {
     public Collection<? extends GrantedAuthority> getAuthorities() {
         return List.of(new SimpleGrantedAuthority(userEntity.getRole().getType()));
     }
+    public Long getUserId() {
+        return userEntity.getUserId();
+    }
 
     @Override
     public String getUsername() {

--- a/src/main/java/com/example/meetty/global/config/auth/SecurityConfig.java
+++ b/src/main/java/com/example/meetty/global/config/auth/SecurityConfig.java
@@ -44,7 +44,7 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll() //
                         .requestMatchers("/ws/**").permitAll()
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-resources/**", "/webjars/**").permitAll()
-                        .requestMatchers("/api/v1/**").authenticated()
+                        .requestMatchers("/v1/**").authenticated()
                         .anyRequest().permitAll()
                 )
                 .exceptionHandling((exceptions) -> exceptions

--- a/src/main/java/com/example/meetty/global/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/example/meetty/global/jwt/JwtTokenProvider.java
@@ -3,7 +3,6 @@ package com.example.meetty.global.jwt;
 import com.example.meetty.global.config.auth.CustomUserDetailsServiceImpl;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.io.DecodingException;
-import jakarta.websocket.DecodeException;
 import lombok.RequiredArgsConstructor;
 
 import lombok.extern.slf4j.Slf4j;
@@ -32,9 +31,10 @@ public class JwtTokenProvider {
     private Long refreshExpirationTime;
 
     // 토큰 생성
-    public String generateToken(String email, Long expireTime, String role) {
+    public String generateToken(String email, Long userId, Long expireTime, String role) {
         Claims claims = Jwts.claims().setSubject(email);
         claims.put("role", role);
+        claims.put("userId", userId);
         Date now = new Date();
         Date expiry = new Date(now.getTime() + expireTime);
 
@@ -47,14 +47,14 @@ public class JwtTokenProvider {
     }
 
     // 액세스 토큰 만들기
-    public String createAccessToken(String email, String role) {
-        return generateToken(email, accessExpirationTime, role);
+    public String createAccessToken(String email, Long userId, String role) {
+        return generateToken(email, userId, accessExpirationTime, role);
     }
 
 
     // 리프레시 토큰 만들기
-    public String createRefreshToken(String email, String role) {
-        return generateToken(email, refreshExpirationTime, role);
+    public String createRefreshToken(String email, Long userId, String role) {
+        return generateToken(email, userId, refreshExpirationTime, role);
     }
 
 

--- a/src/main/java/com/example/meetty/image/entity/UserImageEntity.java
+++ b/src/main/java/com/example/meetty/image/entity/UserImageEntity.java
@@ -19,7 +19,7 @@ public class UserImageEntity {
     @Column(name = "url", nullable = false)
     private String url;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE, orphanRemoval = true)
     @JoinColumn(name = "user_id")
     private UserEntity userEntity;
 

--- a/src/main/java/com/example/meetty/oauth2/hanlder/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/example/meetty/oauth2/hanlder/OAuth2LoginSuccessHandler.java
@@ -42,18 +42,18 @@ public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHan
         CustomUserDetails customUserDetails = (CustomUserDetails) authentication.getPrincipal();
         String email = customUserDetails.getUsername();
 
-        String accessToken = jwtTokenProvider.createAccessToken(email, UserRole.ROLE_USER.getType());
-        String refreshToken = jwtTokenProvider.createRefreshToken(email, UserRole.ROLE_USER.getType());
-
         UserEntity userEntity = userRepository.findByEmail(email)
                 .orElseThrow(() -> new RuntimeException("사용자 정보를 찾을 수 없습니다."));
+
+        String accessToken = jwtTokenProvider.createAccessToken(email, userEntity.getUserId(),UserRole.ROLE_USER.getType());
+        String refreshToken = jwtTokenProvider.createRefreshToken(email, userEntity.getUserId(), UserRole.ROLE_USER.getType());
 
         log.info("OAuth2 로그인 성공: {}", email);
         log.info("accessToken: {}", accessToken);
         log.info("refreshToken: {}", refreshToken);
 
         // 리프레시 토큰 저장
-        refreshTokenRedisService.saveRefreshToken(email, refreshToken, Duration.ofMillis(refreshExpirationTime));
+        refreshTokenRedisService.saveRefreshToken(userEntity.getUserId(), refreshToken, Duration.ofMillis(refreshExpirationTime));
 
         // 응답 헤더 및 쿠키 설정
         response.addHeader("Authorization", accessToken);


### PR DESCRIPTION
1. CustomUserDetails에 getUserId를 추가했습니다. (오버라이드 가능한 메소드가 아니라서 임의로 추가해야함, 오버라이드 시 에러 발생)

2. JwtTokenProvider의 generateToken 메소드에 userId를 Claim으로 추가했습니다.

3. 회원가입, 로그인을 제외한 다른 API들은 email -> userId로 userEntity를 조회하도록 변경했습니다.

4. 회원탈퇴 구현했습니다.